### PR TITLE
Adjustable fee rate for transactions

### DIFF
--- a/app/src/main/java/com/goldenraven/padawanwallet/wallet/wallet/WalletBuild.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/wallet/wallet/WalletBuild.kt
@@ -31,6 +31,7 @@ class WalletBuild : Fragment() {
     private lateinit var binding: FragmentWalletBuildBinding
     private lateinit var address: String
     private lateinit var amount: String
+    var feeRate : Float = 1F
     private lateinit var addressFromScanner: String
     private lateinit var transactionDetails: CreateTxResponse
     private lateinit var viewModel: WalletViewModel
@@ -84,14 +85,6 @@ class WalletBuild : Fragment() {
                 Timber.i("[PADAWANLOGS] Inputs were not valid")
             }
         }
-
-        binding.feeRate.setOnClickListener {
-            fireSnackbar(
-                requireView(),
-                SnackbarLevel.INFO,
-                "Choosing your fee rate is a feature currently in development!"
-            )
-        }
     }
 
     private fun buildMessage(): String {
@@ -112,6 +105,7 @@ class WalletBuild : Fragment() {
     private fun verifyTransaction(): Boolean {
         address = binding.sendAddress.text.toString().trim()
         amount = binding.sendAmount.text.toString().trim()
+        feeRate = binding.feeRate.text.toString().toFloat()
 
         if (address == "") {
             fireSnackbar(
@@ -131,9 +125,15 @@ class WalletBuild : Fragment() {
             Timber.i("[PADAWANLOGS] Amount field was empty")
             return false
         }
-
+        if (feeRate <= 0 || feeRate > 200) {
+            fireSnackbar(
+                    requireView(),
+                    SnackbarLevel.WARNING,
+                    "Please input fee rate between 1 to 200"
+            )
+            return false
+        }
         val addresseesAndAmounts: List<Pair<String, String>> = listOf(Pair(address, amount))
-        val feeRate = 1F
 
         Timber.i("[PADAWANLOGS] Send addresses are: $addresseesAndAmounts")
 

--- a/app/src/main/java/com/goldenraven/padawanwallet/wallet/wallet/WalletBuild.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/wallet/wallet/WalletBuild.kt
@@ -12,6 +12,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.Navigation
 import com.goldenraven.padawanwallet.R
 import com.goldenraven.padawanwallet.data.Tx
@@ -54,6 +55,7 @@ class WalletBuild : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        viewModel = ViewModelProvider(this).get(WalletViewModel::class.java)
         val navController = Navigation.findNavController(view)
 
         binding.buttonScan.setOnClickListener {

--- a/app/src/main/java/com/goldenraven/padawanwallet/wallet/wallet/WalletBuild.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/wallet/wallet/WalletBuild.kt
@@ -175,14 +175,19 @@ class WalletBuild : Fragment() {
                     transactionDetails.details.fees.toInt(),
             )
             Timber.i("[PADAWANLOGS] Transaction was broadcast! txid: $txid, txidString: $txidString")
+            fireSnackbar(
+                    requireView(),
+                    SnackbarLevel.INFO,
+                    "Transaction was broadcast successfully!"
+            )
         } catch (e: Throwable) {
             Timber.i("[PADAWANLOGS] ${e.message}")
-        }
-        fireSnackbar(
+            fireSnackbar(
                 requireView(),
-                SnackbarLevel.INFO,
-                "Transaction was broadcast successfully!"
-        )
+                SnackbarLevel.ERROR,
+                "Error: ${e.message}"
+            )
+        }
     }
 
     private fun addTxToDatabase(txid: String, timestamp: String, txSatsIn: Int, txSatsOut: Int, fees: Int) {
@@ -214,5 +219,4 @@ class WalletBuild : Fragment() {
         Timber.i("[PADAWANLOGS] From addTxToDatabase, the tx is $transaction")
         viewModel.addTx(transaction)
     }
-
 }

--- a/app/src/main/res/layout/fragment_wallet_build.xml
+++ b/app/src/main/res/layout/fragment_wallet_build.xml
@@ -65,7 +65,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView" />
 
-    <TextView
+    <EditText
         android:id="@+id/feeRate"
         android:layout_width="0dp"
         android:layout_height="40dp"
@@ -76,7 +76,7 @@
         android:fontFamily="@font/share_tech_mono"
         android:gravity="center|fill_horizontal"
         android:inputType="number"
-        android:text="1 satoshi/vByte"
+        android:hint="1 satoshi/vByte"
         android:textColor="@color/fg1"
         android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Solves issue #36 

Checklists
- [x]  eba7f83 enables users to input their fee rate instead of to use a predetermined fee rate. This is done by modifying TextView of fee rate to EditText.
- [x]  ef9b24a enables the fee rate given by users to be broadcasted. I did this by editing the WalletBuild.kt and added a fee rate variable which takes the input from fragment_wallet_build.xml.