### PR TITLE
Fix: App stops crashing during sync in WalletHome

### DIFF
--- a/app/src/main/java/com/goldenraven/padawanwallet/wallet/wallet/WalletHome.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/wallet/wallet/WalletHome.kt
@@ -31,6 +31,7 @@ class WalletHome : Fragment() {
 
     private lateinit var viewModel: WalletViewModel
     private lateinit var binding: FragmentWalletHomeBinding
+    private lateinit var rootView: View
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -49,7 +50,7 @@ class WalletHome : Fragment() {
         viewModel.readAllData.observe(viewLifecycleOwner, Observer { tx ->
             adapter.setData(tx)
         })
-
+        rootView = container?.rootView!!
         return binding.root
     }
 
@@ -92,7 +93,7 @@ class WalletHome : Fragment() {
                         viewModel.updateBalance()
                         viewModel.syncTransactionHistory()
                         withContext(Dispatchers.Main) {
-                            fireSnackbar(requireView(), SnackbarLevel.INFO, "Wallet successfully synced!")
+                            fireSnackbar(rootView, SnackbarLevel.INFO, "Wallet successfully synced!")
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #139 by changing _RequireView()_ in the coroutine to using the _rootView_ of WalletHome. This way the coroutine will use the _rootView_ instead of finding the missing child view when the fragment is changed. 

Another way of fixing this would be using a boolean that does not let the coroutine use the snackbar when the fragment is paused, do let me know if this is not the ideal solution! 

The other snackbars need not be changed since they are not launched in a coroutine.