### PR TITLE
Fix: Users with old DB will not crash on launch

### DIFF
--- a/app/src/main/java/com/goldenraven/padawanwallet/data/TxDatabase.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/data/TxDatabase.kt
@@ -29,7 +29,9 @@ abstract class TxDatabase: RoomDatabase() {
                     context.applicationContext,
                     TxDatabase::class.java,
                     "transaction_history",
-                ).build()
+                )
+                    .fallbackToDestructiveMigration()
+                    .build()
                 INSTANCE = instance
                 return instance
             }


### PR DESCRIPTION
Fixes #171 by adding a `.fallbackToDestructiveMigration()` method during the DB creation so users with old DB versions will have them cleared and recreated.