### PR TITLE
Feature: Added APK Generation to android.yaml

### DIFF
--- a/.github/workflows/android_build.yaml
+++ b/.github/workflows/android_build.yaml
@@ -17,3 +17,12 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
+
+      - name: Build debug APK
+        run: bash ./gradlew assembleDebug --stacktrace
+        
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: app
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Added step in the `android.yaml` file to create a debug APK file to `app/build/outputs/apk/debug/app-debug.apk`. For signed APK files we would have to use Github Secrets. 