### PR TITLE
Feature: Adding basic tutorial home

### DIFF
--- a/app/src/main/java/com/goldenraven/padawanwallet/HomeScreen.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/HomeScreen.kt
@@ -33,7 +33,6 @@ internal fun HomeScreen(navController: NavController) {
 
     val scope = rememberCoroutineScope()
 
-    @OptIn(ExperimentalMaterial3Api::class)
     val drawerState = rememberDrawerState(DrawerValue.Closed)
 
     val items = listOf(Icons.Default.Favorite, Icons.Default.Face, Icons.Default.Email, Icons.Default.Face)
@@ -115,8 +114,12 @@ internal fun HomeScreen(navController: NavController) {
             Scaffold(
                 topBar = { PadawanAppBar(scope, drawerState) },
                 bottomBar = { BottomNavigationBar(navControllerWalletNavigation) },
-            ) {
-                WalletNavigation(navControllerWalletNavigation)
+            ) { innerPadding ->
+                Box(
+                    modifier = Modifier.padding(innerPadding)
+                ) {
+                    WalletNavigation(navControllerWalletNavigation)
+                }
             }
         }
     )
@@ -154,7 +157,7 @@ internal fun BottomNavigationBar(navControllerWalletNavigation: NavController) {
             selected = selectedItem == 1,
             onClick = {
                 selectedItem = 1
-                navControllerWalletNavigation.navigate(Screen.TutorialsScreen.route)
+                navControllerWalletNavigation.navigate(Screen.TutorialsHomeScreen.route)
             },
             colors = NavigationBarItemDefaults.colors(
                 selectedIconColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/Screen.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/Screen.kt
@@ -18,6 +18,7 @@ sealed class Screen(val route: String) {
     // wallet screens
     object WalletScreen : Screen("wallet_screen")
     object TutorialsScreen : Screen("tutorials_screen")
+    object TutorialsHomeScreen : Screen("tutorials_home_screen")
 
     // drawer screens
     object AboutScreen : Screen("about_screen")

--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/tutorials/TutorialsHomeScreen.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/tutorials/TutorialsHomeScreen.kt
@@ -1,0 +1,86 @@
+package com.goldenraven.padawanwallet.ui.tutorials
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.goldenraven.padawanwallet.R
+import com.goldenraven.padawanwallet.theme.md_theme_dark_background
+import com.goldenraven.padawanwallet.theme.md_theme_dark_background2
+import com.goldenraven.padawanwallet.ui.Screen
+
+@OptIn(ExperimentalMaterial3Api::class, androidx.compose.animation.ExperimentalAnimationApi::class)
+@Composable
+internal fun TutorialsHomeScreen(navController: NavController) {
+
+    val tutorialsNameList = arrayListOf(
+        listOf(stringResource(R.string.E1_title), stringResource(R.string.concept)),
+        listOf(stringResource(R.string.E2_title), stringResource(R.string.concept)),
+        listOf(stringResource(R.string.E3_title), stringResource(R.string.skill)),
+        listOf(stringResource(R.string.E4_title), stringResource(R.string.concept)),
+        listOf(stringResource(R.string.E5_title), stringResource(R.string.skill)),
+        listOf(stringResource(R.string.E6_title), stringResource(R.string.concept)),
+        listOf(stringResource(R.string.E7_title), stringResource(R.string.concept)),
+        listOf(stringResource(R.string.E8_title), stringResource(R.string.skill))
+    )
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(md_theme_dark_background)
+    ) {
+        itemsIndexed(tutorialsNameList) { index, item ->
+            Card(
+                shape = RoundedCornerShape(8.dp),
+                containerColor = md_theme_dark_background2,
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .clickable(onClick = {
+                        navController.navigate(Screen.TutorialsScreen.route + "/$index")
+                    })
+            ) {
+                Text(
+                    text = item[0],
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier
+                        .align(
+                            alignment = Alignment.CenterHorizontally
+                        )
+                        .padding(
+                            top = 16.dp,
+                        )
+                )
+                Text(
+                    text = item[1],
+                    fontStyle = FontStyle.Italic,
+                    fontSize = 14.sp,
+                    modifier = Modifier
+                        .align(
+                            alignment = Alignment.CenterHorizontally
+                        )
+                        .padding(
+                            bottom = 16.dp,
+                        )
+                )
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/tutorials/TutorialsScreen.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/tutorials/TutorialsScreen.kt
@@ -1,4 +1,4 @@
-package com.goldenraven.padawanwallet.ui.wallet
+package com.goldenraven.padawanwallet.ui.tutorials
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -6,15 +6,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
 import com.goldenraven.padawanwallet.theme.md_theme_dark_background
 
 @Composable
-internal fun TutorialsScreen() {
+fun TutorialsScreen(navController: NavController, tutorialId: String) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(md_theme_dark_background)
     ) {
-        Text(text = "I am a tutorials")
+        Text(text = tutorialId)
     }
 }
+

--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletNavigation.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletNavigation.kt
@@ -10,7 +10,11 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import com.goldenraven.padawanwallet.ui.Screen
+import com.goldenraven.padawanwallet.ui.tutorials.TutorialsHomeScreen
+import com.goldenraven.padawanwallet.ui.tutorials.TutorialsScreen
 import com.google.accompanist.navigation.animation.AnimatedNavHost
 import com.google.accompanist.navigation.animation.composable
 
@@ -44,7 +48,7 @@ fun WalletNavigation(navControllerWalletNavigation: NavHostController) {
 
         // Tutorials
         composable(
-            route = Screen.TutorialsScreen.route,
+            route = Screen.TutorialsHomeScreen.route,
             enterTransition = {
                 slideIntoContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(animationDuration))
             },
@@ -57,6 +61,30 @@ fun WalletNavigation(navControllerWalletNavigation: NavHostController) {
             popExitTransition = {
                 slideOutOfContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(animationDuration))
             }
-        ) { TutorialsScreen() }
+        ) { TutorialsHomeScreen(navController = navControllerWalletNavigation) }
+
+        composable(
+            route = Screen.TutorialsScreen.route + "/{tutorialId}",
+            arguments = listOf(navArgument("tutorialId") { type = NavType.StringType }),
+            enterTransition = {
+                slideIntoContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(animationDuration))
+            },
+            popEnterTransition = {
+                slideIntoContainer(AnimatedContentScope.SlideDirection.Start, animationSpec = tween(animationDuration))
+            },
+            exitTransition = {
+                slideOutOfContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(animationDuration))
+            },
+            popExitTransition = {
+                slideOutOfContainer(AnimatedContentScope.SlideDirection.End, animationSpec = tween(animationDuration))
+            }
+        ) { backStackEntry ->
+            backStackEntry.arguments?.getString("tutorialId")?.let {
+                TutorialsScreen(
+                    navController = navControllerWalletNavigation,
+                    tutorialId = it
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
Removed `@OptIn(ExperimentalMaterial3Api::class)` from `HomeScreen.kt` since it is already called at the start of the class.

Added `innerPadding` to the `BottomBar` so that it does not cover the contents in the main screen.

Refactored current `TutorialsScreen` to `TutorialsHomeScreen`.

Added `TutorialsHomeScreen` to show list of all tutorials, and each is clickable to the `TutorialsScreen` with the `tutorialId` as an argument. 