### PR TITLE
Feature: Adding CI integration tests to android_build.yaml

### DIFF
--- a/.github/workflows/android_build.yaml
+++ b/.github/workflows/android_build.yaml
@@ -4,6 +4,7 @@ on: pull_request
 
 jobs: 
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Check out PR branch
@@ -17,3 +18,27 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
+
+  instrumentation_tests:
+    name: Instrumentation Tests
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        api-level: [26, 31]
+        arch: [x86_64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Run Tests
+        uses: ReactiveCircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: ${{ matrix.arch }}
+          script: ./gradlew connectedCheck 


### PR DESCRIPTION
Moved the CI changes to this PR. The changes are just additions to the `android_build.yaml` file. 