### PR TITLE
Fix: QR Scanner Crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,9 +118,9 @@ dependencies {
 
     // QR codes
     implementation("com.google.zxing:core:3.4.1")
-    implementation("androidx.camera:camera-camera2:1.0.2")
-    implementation("androidx.camera:camera-lifecycle:1.0.2")
-    implementation("androidx.camera:camera-view:1.2.0-alpha01")
+    implementation("androidx.camera:camera-camera2:1.1.0-rc01")
+    implementation("androidx.camera:camera-lifecycle:1.1.0-rc01")
+    implementation("androidx.camera:camera-view:1.1.0-rc01")
 
     // Room
     implementation("androidx.room:room-runtime:2.4.2")


### PR DESCRIPTION
Fix #211 Changed the `androidx.camera:camera-view` dependency to align with the other camerax dependencies. 