### PR TITLE
Docs: Add CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing to Padawan Wallet
+
+First off, thanks for taking the time to contribute! 🎉🎉
+
+When contributing to this repository, please first discuss the change you wish to make via issue with the maintainers of this repository before making a change. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.


### PR DESCRIPTION
I have added a Code of conduct along with Contributing guidelines to the project. In my Contributing guideline, I have not provided a link for the IHR Code of conduct, in case this gets merged I would add the link else the link would redirect to my repo. Let me know what you think about the rules and approach I have provided. @thunderbiscuit sir incase you need some changes let me know I would make and send the PR again.

Solved issue https://github.com/thunderbiscuit/padawan-wallet/issues/245