### PR TITLE
Feat: Change copy icon and text after clicked

### DIFF
--- a/app/src/main/res/drawable/ic_checked.xml
+++ b/app/src/main/res/drawable/ic_checked.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M16.59,7.58L10,14.17l-3.59,-3.58L5,12l5,5 8,-8zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,5 +85,6 @@
     <string name="copyAddrStr">Copy</string>
     <string name="errorFaucet">Error: Faucet Not Available</string>
     <string name="oneTimeFaucet">Error: you\'ve already received testnet coins!</string>
+    <string name="textCopied">Copied</string>
 
 </resources>


### PR DESCRIPTION
fixed: #262 

The icon and text remain the same even after copying the key.
implemented the text from "copy" to "copied' and the default icon with a check icon and then reset to the default text and icon after a short delay.

How it looks in-app : 


https://user-images.githubusercontent.com/73611313/224526390-2e41e8cf-ed58-4d9a-977d-55ca516e0d16.mp4



