### PR TITLE
fix: Double click on receive or send button opens fragment multiple times

### DIFF
--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletRootScreen.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletRootScreen.kt
@@ -39,6 +39,7 @@ import com.goldenraven.padawanwallet.theme.*
 import com.goldenraven.padawanwallet.ui.FadedVerticalDivider
 import com.goldenraven.padawanwallet.ui.Screen
 import com.goldenraven.padawanwallet.ui.standardBorder
+import com.goldenraven.padawanwallet.utils.ClickHelper
 import com.goldenraven.padawanwallet.utils.formatInBtc
 import io.ktor.http.*
 
@@ -252,7 +253,7 @@ fun SendReceive(navController: NavHostController) {
             .padding(top = 4.dp)
     ) {
         Button(
-            onClick = { navController.navigate(Screen.ReceiveScreen.route) },
+            onClick = {ClickHelper.getInstance().clickOnce{ navController.navigate(Screen.ReceiveScreen.route) } },
             colors = ButtonDefaults.buttonColors(containerColor = padawan_theme_button_secondary),
             shape = RoundedCornerShape(20.dp),
             border = standardBorder,
@@ -270,7 +271,7 @@ fun SendReceive(navController: NavHostController) {
             }
         }
         Button(
-            onClick = { navController.navigate(Screen.SendScreen.route) },
+            onClick = { ClickHelper.getInstance().clickOnce{ navController.navigate(Screen.SendScreen.route) } },
             colors = ButtonDefaults.buttonColors(containerColor = padawan_theme_button_primary),
             shape = RoundedCornerShape(20.dp),
             border = standardBorder,

--- a/app/src/main/java/com/goldenraven/padawanwallet/utils/ClickHelper.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/utils/ClickHelper.kt
@@ -1,0 +1,21 @@
+package com.goldenraven.padawanwallet.utils
+
+class ClickHelper private constructor() {
+    private val now: Long
+        get() = System.currentTimeMillis()
+    private var lastEventTimeMs: Long = 0
+    fun clickOnce(event: () -> Unit) {
+        if (now - lastEventTimeMs >= 800L) {
+            event.invoke()
+        }
+        lastEventTimeMs = now
+    }
+    companion object {
+        @Volatile
+        private var instance: ClickHelper? = null
+        fun getInstance() =
+            instance ?: synchronized(this) {
+                instance ?: ClickHelper().also { instance = it }
+            }
+    }
+}


### PR DESCRIPTION
fixed: #287 
When we double-click the receive button, it opens the receive fragment twice, and just like with the send button, we must repeatedly hit the back button to close it.

Fix:
Created a ClickHelper class which keep record of last clicked time and compare with current time if greater then 800ms then event will execute otherwise not.

https://user-images.githubusercontent.com/76438283/230607783-c0b09046-a2e7-4335-a8ed-f6d8a8402d37.mp4

