### PR TITLE
Increase finish button padding

### DIFF
--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/chapters/ChapterScreen.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/chapters/ChapterScreen.kt
@@ -185,7 +185,7 @@ fun ChapterButtons(
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.padding(vertical = 8.dp)
+                    modifier = Modifier.padding(vertical = 10.dp)
                 ) {
                     Text(
                         text = "Finish",


### PR DESCRIPTION
Fixes #296 
Now the `Finish` button is the same size as the other buttons.
![WhatsApp Image 2023-04-10 at 12 51 21 AM](https://user-images.githubusercontent.com/17739006/230792437-6913eb08-fea1-4471-ab6d-ea8e22291712.jpeg)
