### PR TITLE
Proposed Fix For: Bug: Double click on receive or send button opens fragment multiple times #287

### DIFF
--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/ReceiveScreen.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/ReceiveScreen.kt
@@ -8,20 +8,18 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.navigation.NavHostController
 import com.goldenraven.padawanwallet.theme.*
 import com.goldenraven.padawanwallet.ui.PadawanAppBar
@@ -45,6 +43,23 @@ internal fun ReceiveScreen(
     LaunchedEffect(address){
         withContext(Dispatchers.IO){
             QR = addressToQR(address)
+        }
+    }
+
+    val lifeCycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifeCycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_PAUSE) {
+                println("onPause called")
+            }
+        }
+
+        lifeCycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            viewModel.isRecieveScreenOpen.value = false
+            lifeCycleOwner.lifecycle.removeObserver(observer)
         }
     }
 

--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/SendScreen.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/SendScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -38,6 +39,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.navigation.NavHostController
 import com.goldenraven.padawanwallet.R
 import com.goldenraven.padawanwallet.data.Wallet
@@ -79,6 +82,23 @@ internal fun SendScreen(navController: NavHostController, walletViewModel: Walle
             recipientAddress.value = it
 
         navController.currentBackStackEntry?.savedStateHandle?.remove<String>("BTC_Address")
+    }
+
+    val lifeCycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifeCycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_PAUSE) {
+                println("onPause called")
+            }
+        }
+
+        lifeCycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            walletViewModel.isSendScreenOpen.value = false
+            lifeCycleOwner.lifecycle.removeObserver(observer)
+        }
     }
 
     val bottomSheetScaffoldState = rememberBottomSheetScaffoldState(

--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletNavigation.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletNavigation.kt
@@ -106,7 +106,10 @@ fun WalletNavigation(
             popExitTransition = {
                 slideOutOfContainer(AnimatedContentScope.SlideDirection.Down, animationSpec = tween(animationDuration))
             }
-        ) { ReceiveScreen(navController = navControllerWalletNavigation, walletViewModel) }
+        ) {
+            walletViewModel.isRecieveScreenOpen.value = true
+            ReceiveScreen(navController = navControllerWalletNavigation, walletViewModel)
+        }
 
 
         // Send
@@ -124,7 +127,10 @@ fun WalletNavigation(
             popExitTransition = {
                 slideOutOfContainer(AnimatedContentScope.SlideDirection.Down, animationSpec = tween(animationDuration))
             }
-        ) { SendScreen(navController = navControllerWalletNavigation, walletViewModel = walletViewModel) }
+        ) {
+            walletViewModel.isSendScreenOpen.value = true
+            SendScreen(navController = navControllerWalletNavigation, walletViewModel = walletViewModel)
+        }
 
 
         // Transaction screen

--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletRootScreen.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletRootScreen.kt
@@ -70,7 +70,7 @@ internal fun WalletRootScreen(
         // if (walletViewModel.isOnlineVariable.value == false) { NoNetworkBanner(walletViewModel, context) }
         BalanceBox(balance = balance ?: 0uL, viewModel = walletViewModel)
         Spacer(modifier = Modifier.height(height = 12.dp))
-        SendReceive(navController = navController)
+        SendReceive(navController = navController, walletViewModel = walletViewModel)
         TransactionListBox(tempOpenFaucetDialog = tempOpenFaucetDialog, transactionList = transactionList, navController = navController)
     }
 }
@@ -267,13 +267,20 @@ fun formatCurrency(amount: String): String {
 }
 
 @Composable
-fun SendReceive(navController: NavHostController) {
+fun SendReceive(
+    navController: NavHostController,
+    walletViewModel: WalletViewModel
+) {
     Row(
         modifier = Modifier
             .padding(top = 4.dp)
     ) {
         Button(
-            onClick = { navController.navigate(Screen.ReceiveScreen.route) },
+            onClick = {
+                if (walletViewModel.isRecieveScreenOpen.value!=null && walletViewModel.isRecieveScreenOpen.value!=true) {
+                    navController.navigate(Screen.ReceiveScreen.route)
+                }
+            },
             colors = ButtonDefaults.buttonColors(containerColor = padawan_theme_button_secondary),
             shape = RoundedCornerShape(20.dp),
             border = standardBorder,
@@ -291,7 +298,11 @@ fun SendReceive(navController: NavHostController) {
             }
         }
         Button(
-            onClick = { navController.navigate(Screen.SendScreen.route) },
+            onClick = {
+                if (walletViewModel.isSendScreenOpen.value!=null && walletViewModel.isSendScreenOpen.value!=true) {
+                    navController.navigate(Screen.SendScreen.route)
+                }
+            },
             colors = ButtonDefaults.buttonColors(containerColor = padawan_theme_button_primary),
             shape = RoundedCornerShape(20.dp),
             border = standardBorder,

--- a/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/goldenraven/padawanwallet/ui/wallet/WalletViewModel.kt
@@ -66,6 +66,9 @@ class WalletViewModel(
 
     var isOnlineVariable: MutableLiveData<Boolean> = MutableLiveData(false)
 
+    val isRecieveScreenOpen: MutableLiveData<Boolean> = MutableLiveData(false)
+    val isSendScreenOpen: MutableLiveData<Boolean> = MutableLiveData(false)
+
     init {
         Log.i(TAG, "The WalletScreen viewmodel is being initialized...")
 


### PR DESCRIPTION
I've used two MutableLiveData in the WalletViewModel which hold the Live state(whether currently open or closed) of the SendScreen and the RecieveScreen, to determine in real-time whether they're open or closed. 
Using the above states, the onClick properties of the Send and Recieve buttons are handled respectively, and it solves the present issue. 
Do review the code and send in your feedbacks.