### PR TITLE
fix: create ios directory before generating Localizable.xcstrings

### DIFF
--- a/localization/scripts/build-xcstrings.py
+++ b/localization/scripts/build-xcstrings.py
@@ -6,7 +6,10 @@ from glob import glob
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT_DIR = os.path.join(SCRIPT_DIR, "..")
+OUTPUT_DIR = "../ios"
 OUTPUT_FILE = os.path.join(SCRIPT_DIR, "..", "ios", "Localizable.xcstrings")
+
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def load_all_languages(input_dir):
     strings = {}


### PR DESCRIPTION
## What Happened?
When I ran `build-xcstrings.py` on my machine, I got the following error

```
The python scritp wans't localizing ios/Localizable.xcstrings because the script was not creating the directory before use
with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: '~/repos/Open/padawan-wallet/localization/scripts/../ios/Localizable.xcstrings
```

## The Fix
I added a command to `build-xcstrings.py` to create the `ios` directory before attempting to write the `Localizable.xcstrings` file.