### PR TITLE
[iOS]: Added PadawanButton and FilledButton

### DIFF
--- a/iOS/PadawanWallet/Features/Onboarding/OnboardingView.swift
+++ b/iOS/PadawanWallet/Features/Onboarding/OnboardingView.swift
@@ -14,6 +14,13 @@ struct OnboardingView: View {
             Text("Onboarding Screen")
                 .font(.largeTitle)
 
+            PadawanButton(
+                title: "Teste",
+                action: {
+                    print("teste")
+                }
+            )
+            
             Button("Continue to Wallet") {
                 isOnboarding = false
             }

--- a/iOS/PadawanWallet/Resources/Fonts/Fonts+Util.swift
+++ b/iOS/PadawanWallet/Resources/Fonts/Fonts+Util.swift
@@ -31,4 +31,8 @@ extension Fonts {
     static var subtitle: SwiftUI.Font {
         Fonts.font(.regular, 18)
     }
+    
+    static var caption: SwiftUI.Font {
+        Fonts.font(.medium, 18)
+    }
 }

--- a/iOS/PadawanWallet/Resources/Fonts/Fonts+Util.swift
+++ b/iOS/PadawanWallet/Resources/Fonts/Fonts+Util.swift
@@ -32,6 +32,10 @@ extension Fonts {
         Fonts.font(.regular, 18)
     }
     
+    static var body: SwiftUI.Font {
+        Fonts.font(.regular, 18)
+    }
+    
     static var caption: SwiftUI.Font {
         Fonts.font(.medium, 18)
     }

--- a/iOS/PadawanWallet/Theme/UI Components/Buttons/FilledButton.swift
+++ b/iOS/PadawanWallet/Theme/UI Components/Buttons/FilledButton.swift
@@ -1,0 +1,108 @@
+//
+//  FilledButton.swift
+//  PadawanWallet
+//
+//  Created by Rubens Machion on 25/07/25.
+//
+
+import SwiftUI
+
+struct FilledButton: View {
+    @Environment(\.padawanColors) private var colors
+    
+    private let title: String
+    private let icon: Image?
+    private let titleColor: Color?
+    private let iconTintColor: Color?
+    private let backgroundColor: Color?
+    
+    private let action: (() -> Void)?
+    
+    init(
+        title: String,
+        icon: Image? = nil,
+        titleColor: Color? = nil,
+        iconTintColor: Color? = nil,
+        backgroundColor: Color? = nil,
+        action: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.icon = icon
+        self.titleColor = titleColor
+        self.iconTintColor = iconTintColor
+        self.backgroundColor = backgroundColor
+        self.action = action
+    }
+    
+    var body: some View {
+        Button {
+            
+        } label: {
+            HStack {
+                Text(title)
+                    .font(Fonts.body)
+                    .foregroundStyle(titleColor ?? colors.text)
+                if let icon {
+                    Spacer()
+                    icon
+                        .foregroundStyle(iconTintColor ?? colors.accent1)
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, minHeight: 50)
+            .background(backgroundColor ?? colors.background2)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+}
+
+#if DEBUG
+private struct PreviewSample: View {
+    
+    private let colors: PadawanColors
+    
+    init(colors: PadawanColors = .tatooineDesert) {
+        self.colors = colors
+    }
+    
+    var body: some View {
+        ZStack {
+            colors.background
+            VStack(spacing: 16) {
+                FilledButton(
+                    title: "Title"
+                )
+                
+                FilledButton(
+                    title: "With Icon",
+                    icon: Image(systemName: "chevron.right.2")
+                )
+                
+                FilledButton(
+                    title: "Destructive",
+                    titleColor: colors.text,
+                    backgroundColor: colors.errorRed
+                )
+                
+                FilledButton(
+                    title: "Fully Customized",
+                    icon: Image(systemName: "square.and.arrow.up"),
+                    titleColor: .white,
+                    iconTintColor: colors.text,
+                    backgroundColor: colors.accent1
+                )
+            }
+            .padding()
+        }
+        .ignoresSafeArea()
+    }
+}
+
+#Preview("TatooineDesert") {
+    PreviewSample(colors: .tatooineDesert)
+}
+
+#Preview("VaderDark") {
+    PreviewSample(colors: .vaderDark)
+}
+#endif

--- a/iOS/PadawanWallet/Theme/UI Components/Buttons/PadawanButton.swift
+++ b/iOS/PadawanWallet/Theme/UI Components/Buttons/PadawanButton.swift
@@ -62,6 +62,7 @@ struct PadawanButton: View {
     }
 }
 
+
 #if DEBUG
 private struct PreviewSample: View {
     var body: some View {

--- a/iOS/PadawanWallet/Theme/UI Components/PadawanButton.swift
+++ b/iOS/PadawanWallet/Theme/UI Components/PadawanButton.swift
@@ -1,0 +1,85 @@
+//
+//  PadawanButton.swift
+//  PadawanWallet
+//
+//  Created by Rubens Machion on 25/07/25.
+//
+
+import SwiftUI
+
+struct PadawanButton: View {
+    @Environment(\.padawanColors) private var colors
+    
+    private let title: String
+    private let icon: Image?
+    
+    private let action: (() -> Void)?
+    
+    init(
+        title: String,
+        icon: Image? = nil,
+        action: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.icon = icon
+        self.action = action
+    }
+    
+    var body: some View {
+        Button {
+            action?()
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.black)
+                    .offset(x: 4, y: 4)
+                
+                HStack {
+                    buildContent()
+                }
+                .foregroundColor(colors.text)
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: 80)
+                .background(colors.accent2)
+                .cornerRadius(12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(.black, lineWidth: 2)
+                )
+            }
+            .contentShape(Rectangle())
+            .frame(maxHeight: 80)
+        }
+    }
+    
+    @ViewBuilder
+    private func buildContent() -> some View {
+        Text(title)
+            .font(Fonts.caption)
+        if let icon {
+            icon
+        }
+    }
+}
+
+#if DEBUG
+private struct PreviewSample: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            PadawanButton(
+                title: "Title"
+            )
+            
+            PadawanButton(
+                title: "With Icon",
+                icon: Image(systemName: "bitcoinsign")
+            )
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    PreviewSample()
+}
+#endif


### PR DESCRIPTION
Created Padawan and FilledButton to use across the app

**PadawanButton**
<img width="250" height="315" alt="Screenshot 2025-07-25 at 18 30 33" src="https://github.com/user-attachments/assets/47791d1a-9cec-4480-8e7c-730f53dc25c2" />


**FilledButton**
<img width="250" height="312" alt="Screenshot 2025-07-25 at 18 30 21" src="https://github.com/user-attachments/assets/a5aeab6c-a166-4581-90d4-460c6e78931e" />
