### PR TITLE
[Android]: add imePadding() to prevent keyboard from overlapping text fields in WalletRecoveryScreen

### DIFF
--- a/Android/app/src/main/java/com/coyotebitcoin/padawanwallet/presentation/ui/screens/intro/WalletRecoveryScreen.kt
+++ b/Android/app/src/main/java/com/coyotebitcoin/padawanwallet/presentation/ui/screens/intro/WalletRecoveryScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -147,6 +148,7 @@ fun MyList(
     Column(
         modifier
             .fillMaxWidth()
+            .imePadding()
             .padding(horizontal = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -158,7 +160,7 @@ fun MyList(
             ) {
                 val leftWordNumber = row * 2 + 1
                 val rightWordNumber = row * 2 + 2
-                
+
                 WordField(
                     wordNumber = leftWordNumber,
                     recoveryPhraseWordMap,


### PR DESCRIPTION
Found this bug on a Samsung A15, where the on-screen keyboard was overlapping the text input fields in WalletRecoveryScreen.
This PR adds the Modifier.imePadding() to the layout to ensure proper visibility of the fields while typing.
No other functional changes were introduced.