### PR TITLE
[iOS] small fix AlertModal

### DIFF
--- a/iOS/PadawanWallet/UI Components/Common/AlertModalView.swift
+++ b/iOS/PadawanWallet/UI Components/Common/AlertModalView.swift
@@ -91,16 +91,18 @@ struct AlertModalView: View {
     @ViewBuilder
     private func buildDock() -> some View {
         buttonsOrientation {
-            PadawanButton(
-                title: data.secondaryButtonTitle,
-                icon: data.secondaryButtonIcon,
-                isDestructive: true,
-                action: {
-                    close()
-                    data.onSecondaryButtonTap?()
-                }
-            )
-            .frame(height: 50)
+            if let onSecondaryButtonTap = data.onSecondaryButtonTap {
+                PadawanButton(
+                    title: data.secondaryButtonTitle,
+                    icon: data.secondaryButtonIcon,
+                    isDestructive: true,
+                    action: {
+                        close()
+                        onSecondaryButtonTap()
+                    }
+                )
+                .frame(height: 50)
+            }
             
             PadawanButton(
                 title: data.primaryButtonTitle,


### PR DESCRIPTION
Small fix to solve AlertModal issue and secondary action not set

### The problem
<img width="400" height="870" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-19 at 10 19 23" src="https://github.com/user-attachments/assets/55d07fd0-3a44-4ec2-a9e3-5223b70336d5" />


### Fix result
<img width="250" height="542" alt="Screenshot 2025-10-19 at 11 20 47" src="https://github.com/user-attachments/assets/8a13bee7-76ac-4141-bc11-f5f0e89fc5c3" />

