### PR TITLE
[Android] Fix sync button width to support longer translations such as French

### DIFF
--- a/Android/app/src/main/java/com/coyotebitcoin/padawanwallet/presentation/ui/screens/wallet/WalletRootScreen.kt
+++ b/Android/app/src/main/java/com/coyotebitcoin/padawanwallet/presentation/ui/screens/wallet/WalletRootScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -288,7 +289,7 @@ fun BalanceBox(
                         ),
                         shape = RoundedCornerShape(20.dp, 20.dp, 0.dp, 0.dp),
                         border = standardBorder,
-                        modifier = Modifier.width(134.dp),
+                        modifier = Modifier.widthIn(min = 134.dp),
                         enabled = !currentlySyncing
                     ) {
                         Row(


### PR DESCRIPTION
The UI of french sync localization `synchronisé` was slightly too long and the last character was moved to the next line, creating a second row which was visually unpleasant to see on the main wallet screen.

<img width="1024" height="721" alt="image" src="https://github.com/user-attachments/assets/408b2e47-e7b4-41a0-9832-ad1793108008" />

The fix is really simple: I replaced the fixed width with responsive constraint (widthIn) to prevent text wrapping in longer translations like French "synchronisé".
Two line changes, it has no impact on other localization UI. Here is the fix:

<img width="1024" height="638" alt="image" src="https://github.com/user-attachments/assets/a335e104-e933-4f09-b820-ab59cdf3bd41" />
